### PR TITLE
Disable cache

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -38,7 +38,7 @@ sub vcl_recv {
     unset req.http.Authorization;
 
     # skip cache lookup
-    return (pass)
+    return (pass);
 }
 
 sub vcl_synth {

--- a/default.vcl
+++ b/default.vcl
@@ -14,7 +14,8 @@ sub vcl_recv {
         return(synth(200, "robots"));
     }
 
-    if ((req.url ~ "^.*\/__health.*$") || (req.url ~ "^.*\/__gtg.*$") || (req.url ~ "^.*\/__kafka-rest-proxy.*$")) {
+    if ((req.url ~ "^.*\/__health.*$") || (req.url ~ "^.*\/__gtg.*$")) {
+        # skip auth and cache lookup
         return (pass);
     } elseif (!req.url ~ "^\/__[\w-]*\/.*$") {
         set req.http.Host = "HOST_HEADER";
@@ -35,6 +36,9 @@ sub vcl_recv {
         return(synth(401, "Authentication required"));
     }
     unset req.http.Authorization;
+
+    # skip cache lookup
+    return (pass)
 }
 
 sub vcl_synth {


### PR DESCRIPTION
- the Publishing Cluster doesn't have any read endpoints, so it's safe to turn off the cache
- this change also re-instates auth on the kafka-proxy
- the change basically skips the `lookup` phase of the request lifecycle, and sends the request to the backend - for more info see:
  - http://book.varnish-software.com/4.0/chapters/VCL_Basics.html
  - http://book.varnish-software.com/4.0/chapters/VCL_Built_in_Subroutines.html#vcl-vcl-recv
- tested in pub-xp cluster:

**before:**

```
$ curl -i  https://pub-xp-up.ft.com/__kafka-rest-proxy
HTTP/1.1 404 Not Found
Age: 0
Content-Type: application/json
Date: Mon, 27 Jun 2016 08:43:28 GMT
Via: 1.1 varnish-v4
X-Cache: MISS
X-Varnish: 229639
Content-Length: 21
Connection: keep-alive
```

**after:**

```
$ curl -i  https://pub-xp-up.ft.com/__kafka-rest-proxy
HTTP/1.1 401 Unauthorized
Date: Mon, 27 Jun 2016 08:45:46 GMT
Server: Varnish
WWW-Authenticate: Basic realm=Secured
X-Varnish: 32784
Content-Length: 0
Connection: keep-alive
```
