### PR TITLE
Added /video endpoint

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -37,6 +37,8 @@ sub vcl_recv {
 
     if (req.url ~ "^\/content.*$") {
         set req.url = regsub(req.url, "content", "__cms-notifier/notify");
+    } elseif (req.url ~ "^\/video.*$") {
+        set req.url = regsub(req.url, "video", "__cms-notifier/notify");
     } elseif (req.url ~ "^\/metadata.*$") {
         set req.url = regsub(req.url, "metadata", "__cms-metadata-notifier/notify");
     } elseif (req.url ~ "\/notification\/wordpress.*$") {


### PR DESCRIPTION
The new endpoint would look like this: `https://<env>-up.ft.com/video` and will forward requests to cms-notifier.

See https://sites.google.com/a/ft.com/universal-publishing/documentation/story-specs/3-mar-2017-next-video-platform-work