### PR TITLE
Feature/copy request url to header

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -27,7 +27,7 @@ sub vcl_recv {
         return(synth(200, "robots"));
     }
 
-    set req.http.X-Varnish-Original-Request-URL = req.url
+    set req.http.X-Varnish-Original-Request-URL = req.url;
     
     if ((req.url ~ "^.*\/__health.*$") || (req.url ~ "^.*\/__gtg.*$")) {
         # skip auth and cache lookup

--- a/default.vcl
+++ b/default.vcl
@@ -29,6 +29,8 @@ sub vcl_recv {
 
     set req.http.X-Varnish-Original-Request-URL = req.url;
     set req.http.X-Varnish-X-Forwarded-For = req.http.X-Forwarded-For
+    set req.http.X-Varnish-Host = req.http.Host
+    set req.http.X-Varnish-X-Forwarded-Host = req.http.X-Forwarded-Host
     
     if ((req.url ~ "^.*\/__health.*$") || (req.url ~ "^.*\/__gtg.*$")) {
         # skip auth and cache lookup

--- a/default.vcl
+++ b/default.vcl
@@ -27,10 +27,9 @@ sub vcl_recv {
         return(synth(200, "robots"));
     }
 
-    set req.http.X-Varnish-Original-Request-URL = req.url;
-    set req.http.X-Varnish-X-Forwarded-For = req.http.X-Forwarded-For;
-    set req.http.X-Varnish-Host = req.http.Host;
-    set req.http.X-Varnish-X-Forwarded-Host = req.http.X-Forwarded-Host;
+    if ((!req.http.X-Original-Request-URL) && req.http.X-Forwarded-For && req.http.Host) {
+        set req.http.X-Original-Request-URL = "https://" + req.http.Host + req.url;
+    }
     
     if ((req.url ~ "^.*\/__health.*$") || (req.url ~ "^.*\/__gtg.*$")) {
         # skip auth and cache lookup

--- a/default.vcl
+++ b/default.vcl
@@ -28,6 +28,7 @@ sub vcl_recv {
     }
 
     set req.http.X-Varnish-Original-Request-URL = req.url;
+    set req.http.X-Varnish-X-Forwarded-For = req.http.X-Forwarded-For
     
     if ((req.url ~ "^.*\/__health.*$") || (req.url ~ "^.*\/__gtg.*$")) {
         # skip auth and cache lookup

--- a/default.vcl
+++ b/default.vcl
@@ -27,6 +27,8 @@ sub vcl_recv {
         return(synth(200, "robots"));
     }
 
+    set req.http.X-Varnish-Original-Request-URL = req.url
+    
     if ((req.url ~ "^.*\/__health.*$") || (req.url ~ "^.*\/__gtg.*$")) {
         # skip auth and cache lookup
         return (pass);

--- a/default.vcl
+++ b/default.vcl
@@ -28,9 +28,9 @@ sub vcl_recv {
     }
 
     set req.http.X-Varnish-Original-Request-URL = req.url;
-    set req.http.X-Varnish-X-Forwarded-For = req.http.X-Forwarded-For
-    set req.http.X-Varnish-Host = req.http.Host
-    set req.http.X-Varnish-X-Forwarded-Host = req.http.X-Forwarded-Host
+    set req.http.X-Varnish-X-Forwarded-For = req.http.X-Forwarded-For;
+    set req.http.X-Varnish-Host = req.http.Host;
+    set req.http.X-Varnish-X-Forwarded-Host = req.http.X-Forwarded-Host;
     
     if ((req.url ~ "^.*\/__health.*$") || (req.url ~ "^.*\/__gtg.*$")) {
         # skip auth and cache lookup


### PR DESCRIPTION
Set an HTTP header `X-Original-Request-URL` so that downstream services can construct URLs in the response based on what host/path the client used to make the request.

The header is only set if it doesn't already exist in the request, so if a chain is somehow re-entrant into the Varnish layer, the header won't be overwritten. I haven't been able to discover any non-contradictory information to determine whether the original request was made with HTTP or HTTPS, so I've made the assumption (which I think is reasonable for our case) that forwarded requests were always made using HTTPS by the client.